### PR TITLE
iOS Fix: hide UIPageControl

### DIFF
--- a/demo/app/main-page.xml
+++ b/demo/app/main-page.xml
@@ -10,7 +10,7 @@
             <Button text="Last" tap="lastPage" />
         </StackLayout>
         
-        <c:Pager row="2" id="pager" pagesCount="5">
+        <c:Pager row="2" id="pager" pagesCount="10" showNativePageIndicator="true" backgroundColor="lightsteelblue">
             <Pager.items>
                 <GridLayout rows="auto, *, auto" columns="*" class="pager-page">
                     <Label text="Slide 1"></Label>

--- a/src/common.ts
+++ b/src/common.ts
@@ -28,6 +28,7 @@ export abstract class Pager extends View implements AddArrayFromBuilder {
     private _pageSpacing: number = 0;
     public static selectedIndexProperty = new Property("selectedIndex", "Pager", new PropertyMetadata(0, PropertyMetadataSettings.None, null, null, onSelectedIndexChanged));
     public static itemsProperty = new Property("items", "Pager", new PropertyMetadata(undefined, PropertyMetadataSettings.AffectsLayout, null, null, onItemsChanged));
+    public static showNativePageIndicatorProperty = new Property("showNativePageIndicator", "Pager", new PropertyMetadata(false));
     public static selectedIndexChangedEvent = "selectedIndexChanged";
 
     public _addArrayFromBuilder(name: string, value: Array<any>) {
@@ -66,6 +67,12 @@ export abstract class Pager extends View implements AddArrayFromBuilder {
     }
     set pageSpacing(value: number) {
         this._pageSpacing = value;
+    }
+    get showNativePageIndicator() {
+        return this._getValue(Pager.showNativePageIndicatorProperty);
+    }
+    set showNativePageIndicator(value: boolean) {
+        this._setValue(Pager.showNativePageIndicatorProperty, value);
     }
     public abstract updateNativeItems(oldItems: Array<View>, newItems: Array<View>): void;
 

--- a/src/ios/pager.ts
+++ b/src/ios/pager.ts
@@ -48,8 +48,6 @@ export class Pager extends common.Pager {
         this._ios = UIPageViewController.alloc().initWithTransitionStyleNavigationOrientationOptions(this._transformer, this._orientation, this._options);
         this._ios.dataSource = PagerDataSource.initWithOwner(that);
         this._ios.delegate = PagerViewControllerDelegate.initWithOwner(that);
-        const pc = this._nativeView.subviews[0];
-        pc.hidden = true;
         const sv = this._nativeView.subviews[1];
         if (this.borderRadius) {
             sv.layer.cornerRadius = this.borderRadius;
@@ -63,10 +61,6 @@ export class Pager extends common.Pager {
         if (this.borderWidth) {
             sv.layer.borderWidth = this.borderWidth;
         }
-        // this._ios.view.sendSubviewToBack(pc)
-        // this._ios.view.frame = CGRectMake(0, 0, utils.ios.getter(UIScreen, UIScreen.mainScreen.bounds).size.width, utils.ios.getter(UIScreen, UIScreen.mainScreen.bounds).size.height - 300);
-        // sv.frame = CGRectMake(0, 0, sv.frame.size.width, sv.frame.size.height);
-        // sv.setNeedsLayout();
     }
 
     get views() {
@@ -253,7 +247,7 @@ class PagerDataSource extends NSObject implements UIPageViewControllerDataSource
 
     pageViewControllerViewControllerBeforeViewController(pageViewController: UIPageViewController, viewControllerBefore: UIViewController): UIViewController {
         let pos = (<PagerView>viewControllerBefore).tag;
-        if (pos === 0) {
+        if (pos === 0 || !this.owner || !this.owner.items) {
             return null;
         } else {
             let prev = pos - 1;
@@ -263,8 +257,7 @@ class PagerDataSource extends NSObject implements UIPageViewControllerDataSource
 
     pageViewControllerViewControllerAfterViewController(pageViewController: UIPageViewController, viewControllerAfter: UIViewController): UIViewController {
         let pos = (<PagerView>viewControllerAfter).tag;
-        let count = this.presentationCountForPageViewController(pageViewController);
-        if (pos === count - 1) {
+        if (!this.owner || !this.owner.items || this.owner.items.length - 1 === pos) {
             return null;
         } else {
             return this.owner.getViewController(pos + 1);
@@ -272,8 +265,9 @@ class PagerDataSource extends NSObject implements UIPageViewControllerDataSource
     }
 
     presentationCountForPageViewController(pageViewController: UIPageViewController): number {
-        if (!this.owner || !this.owner.items) {
-            return 0;
+        if (!this.owner || !this.owner.items || !this.owner.showNativePageIndicator) {
+            // Hide the native UIPageControl (dots)
+            return -1;
         }
         return this.owner.items.length;
     }


### PR DESCRIPTION
- Now hides the UIPageControl by default on iOS
- Added showNativePageIndicator property, in case someone wants to actually show it