### PR TITLE
Angular AoT support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ demo-ng/hooks
 demo-ng/lib
 demo-ng/platforms
 demo-ng/node_modules
-compiled
+angular/compiled
 node_modules
 .vscode
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.js.map
 *.log
 *.ngFactory.ts
+*.metadata.json
 !scripts/*.js
 demo/app/*.js
 demo/*.d.ts

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.js
 *.js.map
 *.log
+*.ngFactory.ts
 !scripts/*.js
 demo/app/*.js
 demo/*.d.ts
@@ -14,6 +15,7 @@ demo-ng/hooks
 demo-ng/lib
 demo-ng/platforms
 demo-ng/node_modules
+compiled
 node_modules
 .vscode
 .idea

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,6 @@
 demo/
 demo-ng/
+angular/compiled
 *.png
 *.log
 *.map

--- a/.npmignore
+++ b/.npmignore
@@ -6,5 +6,6 @@ angular/compiled
 *.map
 *.ts
 !*.d.ts
+*.json
 !*.metadata.json
 screenshots/

--- a/.npmignore
+++ b/.npmignore
@@ -5,4 +5,5 @@ demo-ng/
 *.map
 *.ts
 !*.d.ts
+!*.metadata.json
 screenshots/

--- a/angular/index.d.ts
+++ b/angular/index.d.ts
@@ -1,2 +1,4 @@
+export declare class PagerComponent {
+}
 export declare class PagerModule {
 }

--- a/angular/index.ts
+++ b/angular/index.ts
@@ -36,7 +36,7 @@ registerElement("Pager", () => require("../").Pager, pagerMeta);
     selector: 'Pager',
     template: '<ng-content></ng-content>'
 })
-class PagerComponent {
+export class PagerComponent {
 }
 
 @NgModule({

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "ng.demo.ios": "npm run ng.preparedemo && cd demo-ng && tns emulate ios",
     "ng.demo.ios.device": "npm run ng.preparedemo && cd demo-ng && tns run ios",
     "ng.demo.android": "npm run ng.preparedemo && cd demo-ng && tns run android",
+    "ngc": "npm run ngc.clean && node --max-old-space-size=8192 ./node_modules/.bin/ngc -p tsconfig.aot.json",
+    "ngc.clean": "find src/ angular/ \\( -name '*.metadata.json' -or -name '*.ngsummary.json' -or -name '*.ngfactory.ts' \\) -print -delete",
     "setup": "npm i && cd demo && npm i && cd .. && npm run build && cd demo && tns plugin add .. && cd ..",
     "postclone": "npm i && node scripts/postclone.js"
   },
@@ -45,7 +47,9 @@
   "homepage": "https://github.com/TriniWiz/nativescript-pager",
   "readmeFilename": "README.md",
   "devDependencies": {
-    "@angular/core": "~2.4.7",
+    "@angular/compiler": "^2.4.8",
+    "@angular/compiler-cli": "^2.4.8",
+    "@angular/platform-server": "^2.4.8",
     "zone.js": "~0.7.2",
     "nativescript-angular": "~1.4.0",
     "tns-core-modules": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "ngc": "npm run ngc.clean && node --max-old-space-size=8192 ./node_modules/.bin/ngc -p tsconfig.aot.json",
     "ngc.clean": "find src/ angular/ \\( -name '*.metadata.json' -or -name '*.ngsummary.json' -or -name '*.ngfactory.ts' \\) -print -delete",
     "setup": "npm i && cd demo && npm i && cd .. && npm run build && cd demo && tns plugin add .. && cd ..",
+    "prepublish": "npm run build && npm run ngc",
     "postclone": "npm i && node scripts/postclone.js"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "ng.demo.ios.device": "npm run ng.preparedemo && cd demo-ng && tns run ios",
     "ng.demo.android": "npm run ng.preparedemo && cd demo-ng && tns run android",
     "ngc": "npm run ngc.clean && node --max-old-space-size=8192 ./node_modules/.bin/ngc -p tsconfig.aot.json",
-    "ngc.clean": "find src/ angular/ \\( -name '*.metadata.json' -or -name '*.ngsummary.json' -or -name '*.ngfactory.ts' \\) -print -delete",
+    "ngc.clean": "find src/ angular/ \\( -name '*.metadata.json' -or -name '*.ngsummary.json' -or -name '*.ngfactory.ts' \\) -delete",
     "setup": "npm i && cd demo && npm i && cd .. && npm run build && cd demo && tns plugin add .. && cd ..",
     "prepublish": "npm run build && npm run ngc",
     "postclone": "npm i && node scripts/postclone.js"

--- a/tsconfig.aot.json
+++ b/tsconfig.aot.json
@@ -1,0 +1,50 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "es2015",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "noEmitHelpers": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "removeComments": false,
+    "noImplicitAny": false,
+    "suppressImplicitAnyIndexErrors": true,
+    "declaration": true,
+    "skipLibCheck": true,
+    "noLib": true,
+    "types": [],
+    "baseUrl": ".",
+    "paths": {
+      "ui/*": ["node_modules/tns-core-modules/ui/*"],
+      "xml": ["node_modules/tns-core-modules/xml"],
+      "xhr": ["node_modules/tns-core-modules/xhr"],
+      "text": ["node_modules/tns-core-modules/text"],
+      "data": ["node_modules/tns-core-modules/data"],
+      "fetch": ["node_modules/tns-core-modules/fetch"],
+      "trace": ["node_modules/tns-core-modules/trace"],
+      "color": ["node_modules/tns-core-modules/color"],
+      "http": ["node_modules/tns-core-modules/http"],
+      "timer": ["node_modules/tns-core-modules/timer"],
+      "utils": ["node_modules/tns-core-modules/utils"],
+      "console": ["node_modules/tns-core-modules/console"],
+      "platform": ["node_modules/tns-core-modules/platform"],
+      "application": ["node_modules/tns-core-modules/application"],
+      "image-asset": ["node_modules/tns-core-modules/image-asset"],
+      "image-source": ["node_modules/tns-core-modules/image-source"],
+      "globals": ["node_modules/tns-core-modules/globals"]
+    }
+  },
+  "files": [
+      "node_modules/tns-core-modules/lib.core.d.ts",
+      "node_modules/tns-core-modules/tns-core-modules.d.ts",
+      "node_modules/tns-platform-declarations/android.d.ts",
+      "node_modules/tns-platform-declarations/ios.d.ts",
+      "angular/index.ts",
+      "pager.android.ts",
+      "pager.ios.ts"
+  ],
+  "angularCompilerOptions": {
+    "genDir": "compiled"
+  }
+}

--- a/tsconfig.aot.json
+++ b/tsconfig.aot.json
@@ -10,7 +10,6 @@
     "removeComments": false,
     "noImplicitAny": false,
     "suppressImplicitAnyIndexErrors": true,
-    "declaration": true,
     "skipLibCheck": true,
     "noLib": true,
     "types": [],
@@ -40,11 +39,9 @@
       "node_modules/tns-core-modules/tns-core-modules.d.ts",
       "node_modules/tns-platform-declarations/android.d.ts",
       "node_modules/tns-platform-declarations/ios.d.ts",
-      "angular/index.ts",
-      "pager.android.ts",
-      "pager.ios.ts"
+      "angular/index.ts"
   ],
   "angularCompilerOptions": {
-    "genDir": "compiled"
+    "genDir": "angular/compiled"
   }
 }


### PR DESCRIPTION
This enables the plugin to be used from angular AoT built & bundled apps.

It simply uses ngc to generate .metadata.json files and includes them when publishing.