### PR TITLE
Fix: AoT Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.ngFactory.ts
 *.metadata.json
 !scripts/*.js
+src/**/*.d.ts
 demo/app/*.js
 demo/*.d.ts
 demo/lib

--- a/.npmignore
+++ b/.npmignore
@@ -1,11 +1,12 @@
 demo/
 demo-ng/
-angular/compiled
 *.png
 *.log
 *.map
 *.ts
 !*.d.ts
-*.json
-!*.metadata.json
 screenshots/
+.vscode/
+.idea/
+tsconfig.aot.json
+tsconfig.json

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
     "ng.demo.ios.device": "npm run ng.preparedemo && cd demo-ng && tns run ios",
     "ng.demo.android": "npm run ng.preparedemo && cd demo-ng && tns run android",
     "ngc": "npm run ngc.clean && node --max-old-space-size=8192 ./node_modules/.bin/ngc -p tsconfig.aot.json",
-    "ngc.clean": "find src/ angular/ \\( -name '*.metadata.json' -or -name '*.ngsummary.json' -or -name '*.ngfactory.ts' \\) -delete",
+    "ngc.clean": "find ./ src/ angular/ -name '*.metadata.json' -delete",
     "setup": "npm i && cd demo && npm i && cd .. && npm run build && cd demo && tns plugin add .. && cd ..",
-    "prepublish": "npm run build && npm run ngc",
+    "prepublish": "npm run ngc && npm run build",
     "postclone": "npm i && node scripts/postclone.js"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -48,9 +48,10 @@
   "homepage": "https://github.com/TriniWiz/nativescript-pager",
   "readmeFilename": "README.md",
   "devDependencies": {
-    "@angular/compiler": "^2.4.8",
-    "@angular/compiler-cli": "^2.4.8",
-    "@angular/platform-server": "^2.4.8",
+    "@angular/core": "~2.4.8",
+    "@angular/compiler": "~2.4.8",
+    "@angular/compiler-cli": "~2.4.8",
+    "@angular/platform-server": "~2.4.8",
     "zone.js": "~0.7.2",
     "nativescript-angular": "~1.4.0",
     "tns-core-modules": "^2.5.0",

--- a/tsconfig.aot.json
+++ b/tsconfig.aot.json
@@ -3,13 +3,10 @@
     "target": "es5",
     "module": "es2015",
     "moduleResolution": "node",
-    "sourceMap": true,
-    "noEmitHelpers": true,
-    "emitDecoratorMetadata": true,
+    "removeComments": true,
     "experimentalDecorators": true,
-    "removeComments": false,
-    "noImplicitAny": false,
-    "suppressImplicitAnyIndexErrors": true,
+    "noEmitHelpers": true,
+    "noEmitOnError": false,
     "skipLibCheck": true,
     "noLib": true,
     "types": [],
@@ -39,9 +36,11 @@
       "node_modules/tns-core-modules/tns-core-modules.d.ts",
       "node_modules/tns-platform-declarations/android.d.ts",
       "node_modules/tns-platform-declarations/ios.d.ts",
+      "pager.android.ts", 
+      "pager.ios.ts",
       "angular/index.ts"
   ],
   "angularCompilerOptions": {
-    "genDir": "angular/compiled"
+    "skipTemplateCodegen": true
   }
 }


### PR DESCRIPTION
I may have accidentally nuked an important dependency (@angular/core) 😆 

This also simplifies the ngc build step, making it a little quicker.
And ignores some more files we don't need to publish like tsconfig.

Note to @triniwiz: The `npm run ngc` step will write .js files which should NOT be published, therefore always run `npm run build` afterwards, like I do in the `prepublish` script now.