### PR TITLE
Fix: Android support-library version lock

### DIFF
--- a/platforms/android/include.gradle
+++ b/platforms/android/include.gradle
@@ -1,12 +1,18 @@
 android {
-	productFlavors {
-		'nativescriptpager' {
-			dimension 'nativescriptpager'
-		}
-	}
+    productFlavors {
+        'nativescriptpager' {
+            dimension 'nativescriptpager'
+        }
+    }
 }
 
 dependencies {
-    compile "com.android.support:support-v4:+"
+    def supportVer = "25+";
+
+    if (project.hasProperty("supportVersion")) {
+        supportVer = supportVersion
+    }
+
+    compile "com.android.support:support-v4:$supportVer"
     compile 'com.eftimoff:android-viewpager-transformers:1.0.1@aar'
 }


### PR DESCRIPTION
Inspiration from:

https://github.com/NativeScript/android-runtime/blob/v2.5.0/build-artifacts/project-template-gradle/build.gradle#L187-L193
and nativescript-snackbar's include.gradle
