### PR TITLE
Migrate to Nativescript 3.1

### DIFF
--- a/angular/index.ts
+++ b/angular/index.ts
@@ -1,5 +1,5 @@
 import { Component, NgModule, Directive, ElementRef, TemplateRef, IterableDiffers, ChangeDetectorRef, ViewContainerRef, Input, Inject, forwardRef, ChangeDetectionStrategy, NO_ERRORS_SCHEMA } from "@angular/core";
-import { registerElement, ViewClassMeta, NgView } from "nativescript-angular/element-registry";
+import { registerElement, ViewClassMeta, NgView, CommentNode } from "nativescript-angular/element-registry";
 import { NativeScriptFormsModule } from "nativescript-angular/forms";
 import { View } from "ui/core/view";
 import { Placeholder } from "ui/placeholder";
@@ -16,7 +16,8 @@ export interface ComponentView {
 };
 
 function getSingleViewRecursive(nodes: Array<any>, nestLevel: number): View {
-    const actualNodes = nodes.filter((n) => !!n && n.nodeName !== "#text");
+    // const actualNodes = nodes.filter((n) => !!n && n.nodeName !== "#text");
+    const actualNodes = nodes.filter((n) => !(n as any instanceof CommentNode));
 
     if (actualNodes.length === 0) {
         throw new Error("No suitable views found in list template! Nesting level: " + nestLevel);
@@ -102,7 +103,7 @@ export class PagerComponent {
     }
 
     set selectedIndex(value) {
-        this._selectedIndex = parseInt(<any>value);
+        this._selectedIndex = parseInt(<any>value, 10);
         if (this.viewInitialized) {
             this.pager.selectedIndex = this._selectedIndex;
         }
@@ -182,4 +183,3 @@ export class PagerItemContext {
 })
 export class PagerModule {
 }
-

--- a/angular/index.ts
+++ b/angular/index.ts
@@ -16,7 +16,6 @@ export interface ComponentView {
 };
 
 function getSingleViewRecursive(nodes: Array<any>, nestLevel: number): View {
-    // const actualNodes = nodes.filter((n) => !!n && n.nodeName !== "#text");
     const actualNodes = nodes.filter((n) => !(n as any instanceof CommentNode));
 
     if (actualNodes.length === 0) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-pager",
-  "version": "4.0.1",
+  "version": "4.0.3",
   "description": "",
   "main": "pager",
   "nativescript": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-pager",
-  "version": "4.0.3",
+  "version": "5.0.0",
   "description": "",
   "main": "pager",
   "nativescript": {


### PR DESCRIPTION
In this PR:

- Force radix to 10 in parseInt (Because is good practice in javascript, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt)
- Change nodes.filter (Actual does not work and throw exception "More than one view found in list template!". In my project i have only one StackLayout in pagerItemTemplate but it found one StackLayout and two object, i don't know why. the new filter it's same than telerik-ui-pro@3.0.1 for listview directive)
- Change version to 5.0.0 because, it's compatible only with nativescript 3.1