### PR TITLE
Make the vue part an actual vue plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,19 +52,24 @@ IMPORTANT: Make sure you include `xmlns:pager="nativescript-pager"` on the Page 
 
 ### Vue
 
+
 ```js
+import Vue from 'nativescript-vue'
 import Pager from 'nativescript-pager/vue'
+
+Vue.use(Pager)
 ```
+
 ```html
 <template>
-<Pager :items="items" +alias="item">
+    <Pager :items="items" +alias="item">
         <v-template>
             <GridLayout class="pager-item" rows="auto, *" columns="*">
-                <Label :text="item.title"></Label>
-                <Image  stretch="fill" row="1" :src="item.image"></Image>
+                <Label :text="item.title" />
+                <Image  stretch="fill" row="1" :src="item.image" />
             </GridLayout>
         </v-template>
-        </Pager>
+    </Pager>
 </template>
 ```
 

--- a/demo-vue/src/main.js
+++ b/demo-vue/src/main.js
@@ -1,6 +1,7 @@
 import Vue from 'nativescript-vue'
 import Pager from 'nativescript-pager/vue'
 
+Vue.use(Pager)
 // Could not get vue-router working
 // Not finding the HelloWorld component
 const Master = {
@@ -10,12 +11,12 @@ const Master = {
       <StackLayout>
         <Button text="To Details directly" @tap="$navigateTo(detailPage)" />
         <Pager :items="items" +alias="item">
-        <v-template>
-            <GridLayout class="pager-item" rows="auto, *" columns="*">
-                <Label :text="item.title"></Label>
-                <Image  stretch="fill" row="1" :src="item.image"></Image>
-            </GridLayout>
-        </v-template>
+          <v-template>
+              <GridLayout class="pager-item" rows="auto, *" columns="*">
+                  <Label :text="item.title"></Label>
+                  <Image  stretch="fill" row="1" :src="item.image"></Image>
+              </GridLayout>
+          </v-template>
         </Pager>
       </StackLayout>
     </Page>
@@ -91,7 +92,7 @@ const Detail = {
 //import './styles.scss';
 
 // Uncommment the following to see NativeScript-Vue output logs
-//Vue.config.silent = false;
+Vue.config.silent = false;
 
 
 new Vue({

--- a/src/vue/index.js
+++ b/src/vue/index.js
@@ -1,3 +1,4 @@
-const Vue = require('nativescript-vue');
-const Pager = require('./pager');
-Vue.component('Pager', Pager)
+export default function install(Vue) {
+  Vue.registerElement('NativePager', () => require('../').Pager);
+  Vue.component('Pager', require('./pager').default(Vue))
+}

--- a/src/vue/pager.js
+++ b/src/vue/pager.js
@@ -1,95 +1,89 @@
-const Vue = require('nativescript-vue');
-Vue.registerElement('NativePager', () => require('nativescript-pager').Pager);
-export default {
-  name: 'pager',
-  props: {
-    items: {
-      type: Array,
-      required: true
-    },
-    '+alias': {
-      type: String,
-      default: 'item'
-    },
-    '+index': {
-      type: String
-    }
-  },
-  template: `
-    <native-pager
-    ref="pagerView"
-    :items="items"
-    :selectedIndex="selectedIndex"
-    v-bind="$attrs"
-    v-on="listeners"
-    @selectedIndexChange="onSelectedIndexChange"
-    @itemTap="onItemTap"
-    @itemLoading="onItemLoading">
-    <slot />
-    </native-pager>
-    `,
-  watch: {
-    items: {
-      handler(newVal) {
-        this.$refs.pagerView.setAttribute('items', newVal);
-        this.$refs.pagerView.nativeView.refresh();
+export default function pager(Vue) {
+  return {
+    // name: 'pager',
+    props: {
+      items: {
+        type: Array,
+        required: true
       },
-      deep: true
-    }
-  },
-  created() {
-    // we need to remove the itemTap handler from a clone of the $listeners
-    // object because we are emitting the event ourselves with added data.
-    const listeners = Object.assign({}, this.$listeners);
-    delete listeners.selectedIndexChange;
-    delete listeners.itemTap;
-    this.listeners = listeners;
-  },
-  mounted() {
-    this.getItemContext = (item, index) =>
-      getItemContext(item, index, this.$props['+alias'], this.$props['+index']);
-    this.$refs.pagerView.setAttribute('items', this.items);
-    this.$refs.pagerView.setAttribute(
-      '_itemTemplatesInternal',
-      this.$templates.getKeyedTemplates()
-    );
-    this.$refs.pagerView.setAttribute(
-      '_itemTemplateSelector',
-      (item, index) => {
-        return this.$templates.selectorFn(this.getItemContext(item, index));
+      '+alias': {
+        type: String,
+        default: 'item'
+      },
+      '+index': {
+        type: String
       }
-    );
-  },
-  methods: {
-    onSelectedIndexChange(args) {
-      this.$emit('selectedIndexChange', args);
     },
-    onItemTap(args) {
-      this.$emit(
-        'itemTap',
-        Object.assign({ item: this.items[args.index] }, args)
+    template: `
+    <native-pager
+      ref="pagerView"
+      :items="items"
+      v-bind="$attrs"
+      v-on="listeners"
+      @itemTap="onItemTap"
+      @itemLoading="onItemLoading">
+      <slot />
+    </native-pager>
+  `,
+    watch: {
+      items: {
+        handler(newVal) {
+          this.$refs.pagerView.setAttribute('items', newVal);
+          this.$refs.pagerView.nativeView.refresh();
+        },
+        deep: true
+      }
+    },
+    created() {
+      // we need to remove the itemTap handler from a clone of the $listeners
+      // object because we are emitting the event ourselves with added data.
+      const listeners = Object.assign({}, this.$listeners);
+      delete listeners.itemTap;
+      this.listeners = listeners;
+    },
+    mounted() {
+      this.getItemContext = (item, index) =>
+        getItemContext(item, index, this.$props['+alias'], this.$props['+index']);
+      this.$refs.pagerView.setAttribute('items', this.items);
+      this.$refs.pagerView.setAttribute(
+        '_itemTemplatesInternal',
+        this.$templates.getKeyedTemplates()
+      );
+      this.$refs.pagerView.setAttribute(
+        '_itemTemplateSelector',
+        (item, index) => {
+          return this.$templates.selectorFn(this.getItemContext(item, index));
+        }
       );
     },
-    onItemLoading(args) {
-      const index = args.index;
-      const items = args.object.items;
-      const currentItem =
-        typeof items.getItem === 'function'
-          ? items.getItem(index)
-          : items[index];
-      const name = args.object._itemTemplateSelector(currentItem, index, items);
-      const context = this.getItemContext(currentItem, index);
-      const oldVnode = args.view && args.view[Vue.VUE_VIEW];
-      args.view = this.$templates.patchTemplate(name, context, oldVnode);
+    methods: {
+      onItemTap(args) {
+        this.$emit(
+          'itemTap',
+          Object.assign({item: this.items[args.index]}, args)
+        );
+      },
+      onItemLoading(args) {
+        const index = args.index;
+        const items = args.object.items;
+        const currentItem =
+          typeof items.getItem === 'function'
+            ? items.getItem(index)
+            : items[index];
+        const name = args.object._itemTemplateSelector(currentItem, index, items);
+        const context = this.getItemContext(currentItem, index);
+        const oldVnode = args.view && args.view[Vue.VUE_VIEW];
+        args.view = this.$templates.patchTemplate(name, context, oldVnode);
+      }
     }
-  }
-};
-
-function getItemContext(item, index, alias, index_alias) {
-  return {
-    [alias]: item,
-    [index_alias || '$index']: index,
-    $even: index % 2 === 0,
-    $odd: index % 2 !== 0
   };
+
+  function getItemContext(item, index, alias, index_alias) {
+    return {
+      [alias]: item,
+      [index_alias || '$index']: index,
+      $even: index % 2 === 0,
+      $odd: index % 2 !== 0
+    };
+  }
 }


### PR DESCRIPTION
This changes how the vue subdirectory exports, main difference is that we don't directly import `nativescript-vue` instead we export an `install` function, which accepts `Vue` as the first parameter.

changed the readme to reflect the changes, but it's like any other vue plugin, in the main file of the application, you have to import the plugin and then `Vue.use(Pager)` which will then call the install function, pass in `Vue` and ensure that the plugin is only installed once, regardless how many times `Vue.use(Pager)` is called (this is to prevent issues from installing the same plugin multiple times).

I've also changed the `pager.js` file, which contains a Vue component, to export a factory function, which accepts the Vue parameter. This has been done to eliminate the need of importing `nativescript-vue` and instead it will be passed from the `install` function, which will register the component by calling the factory function.

