### PR TITLE
Fix Vue demo and tsconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@
 *.metadata.json
 src/*.d.ts
 !src/pager.d.ts
-!src/index.d.ts
 !src/references.d.ts
 !src/scripts/*.js
 !seed-tests/*.js
@@ -36,3 +35,4 @@ demo-ng/report/report.html
 demo-ng/report/stats.json
 package-lock.json
 demo-vue/platforms
+!demo-vue/app/main.js

--- a/demo-vue/app/main.js
+++ b/demo-vue/app/main.js
@@ -1,0 +1,12 @@
+import Vue from 'nativescript-vue'
+import App from './components/App'
+import Pager from 'nativescript-pager/vue'
+
+Vue.use(Pager)
+
+// Prints Vue logs when --env.production is *NOT* set while building
+Vue.config.silent = (TNS_ENV === 'production')
+
+new Vue({
+  render: h => h('frame', [h(App)])
+}).$start()

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -19,6 +19,10 @@
         "noImplicitUseStrict": false,
         "noFallthroughCasesInSwitch": true
     },
+    "include":[
+        "*.ts",
+        "!*.d.ts"
+    ],
     "exclude": [
         "node_modules"
     ],


### PR DESCRIPTION
Hey @triniwiz,

I ❤️this plugin and use it in several projects. I wanted to upgrade a Vue app to 9.x and ran into issues running your Vue demo app, so here's a fix. Details:

- You probably have a `main.js` sitting on your machine that never made it to version control because it's `.gitignore`d. I've unignored it and added a `main.js` that's probably quite similar to your local copy.
- Running a demo app twice in a row fails because TSC 3.x errors when trying to generate `index.d.ts` over an existing `index.d.ts`. The change in `tsconfig.json` fixes this behavior.