### PR TITLE
fix(static): static items are not added to pager

### DIFF
--- a/demo-ng/app/app.module.ts
+++ b/demo-ng/app/app.module.ts
@@ -12,6 +12,8 @@ import { DummyComponent } from './dummy.component';
 import { TestMultiComponent } from './test-multi/test-multi.component';
 import { TestListComponent } from './test-list/test-list.component';
 import { StaticComponent } from './static/static.component';
+import { RouterComponent } from './router/router.component';
+import { Page1Component } from './router/page1.component';
 
 @NgModule({
     bootstrap: [AppComponent],
@@ -27,7 +29,9 @@ import { StaticComponent } from './static/static.component';
         TestMultiComponent,
         TestListComponent,
         DummyComponent,
-        StaticComponent
+        StaticComponent,
+        RouterComponent,
+        Page1Component
     ],
     providers: [],
     schemas: [NO_ERRORS_SCHEMA]

--- a/demo-ng/app/app.routing.ts
+++ b/demo-ng/app/app.routing.ts
@@ -7,6 +7,8 @@ import { TestMultiComponent } from './test-multi/test-multi.component';
 import { DummyComponent } from './dummy.component';
 import { TestListComponent } from './test-list/test-list.component';
 import { StaticComponent } from '~/static/static.component';
+import { RouterComponent } from './router/router.component';
+import { Page1Component } from './router/page1.component';
 
 const routes: Routes = [
     {path: '', redirectTo: '/test', pathMatch: 'full'},
@@ -15,6 +17,10 @@ const routes: Routes = [
     {path: 'dummy', component: DummyComponent},
     {path: 'list', component: TestListComponent},
     {path: 'static', component: StaticComponent},
+    {path: 'router-test', component: RouterComponent, children: [
+        {path: 'page1', component: Page1Component},
+        {path: 'page2', component: Page1Component}
+    ]}
 ];
 
 @NgModule({

--- a/demo-ng/app/dummy.component.ts
+++ b/demo-ng/app/dummy.component.ts
@@ -1,12 +1,20 @@
 import { Component } from '@angular/core';
+import { RouterExtensions } from 'nativescript-angular/router';
 
 @Component({
     selector: 'dummy',
     template: `
 		<StackLayout>
-			<Label text="Just a test page - go back now"></Label>
+      <Label text="Just a test page - go back now"></Label>
+      <Button text="go back" (tap)="goBack()"></Button>
+      
 		</StackLayout>
     `
 })
 export class DummyComponent {
+  constructor(private routerExtensions: RouterExtensions){}
+
+  goBack() {
+    this.routerExtensions.back();
+  }
 }

--- a/demo-ng/app/router/page1.component.html
+++ b/demo-ng/app/router/page1.component.html
@@ -1,0 +1,16 @@
+<GridLayout rows="auto, auto,*" columns="*">
+  <Button row="0" text="Go to page 1" (tap)="goToPageOne()"></Button>
+  <Button row="1" text="Go to page 2" (tap)="goToPageTwo()"></Button>
+  <StackLayout row="2">
+      <ns-static></ns-static>
+  </StackLayout>
+  <!-- <Pager  [items]="items | async" loadMoreCount="5" #pager [selectedIndex]="currentPagerIndex" (selectedIndexChange)="onIndexChanged($event)" class="pager"
+      backgroundColor="lightsteelblue">
+      <ng-template let-i="index" let-item="item">
+          <GridLayout (loaded)="loaded(i)" class="pager-item" rows="auto, *" columns="*" backgroundColor="red">
+              <Label [text]="item.title"></Label>
+              <Image heighht="300" (loaded)="loadedImage($event)" stretch="fill" row="1" [src]="item.image"></Image>
+          </GridLayout>
+      </ng-template>
+  </Pager> -->
+</GridLayout>

--- a/demo-ng/app/router/page1.component.ts
+++ b/demo-ng/app/router/page1.component.ts
@@ -1,0 +1,20 @@
+import { Component, OnInit } from '@angular/core';
+import { RouterExtensions } from 'nativescript-angular/router';
+
+@Component({
+  selector: 'page1',
+  moduleId: module.id,
+  templateUrl: './page1.component.html'
+  
+})
+
+export class Page1Component implements OnInit {
+  constructor(private routerExtensions: RouterExtensions) { }
+  goToPageOne() {
+    this.routerExtensions.navigate(['/router-test/page1'])
+  }
+  goToPageTwo() {
+    this.routerExtensions.navigate(['/router-test/page2'])
+  }
+  ngOnInit() { }
+}

--- a/demo-ng/app/router/router.component.ts
+++ b/demo-ng/app/router/router.component.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'router',
+  template: `<router-outlet></router-outlet>`
+})
+
+export class RouterComponent implements OnInit {
+  constructor() { }
+
+  ngOnInit() { }
+}

--- a/demo-ng/app/test/test.component.html
+++ b/demo-ng/app/test/test.component.html
@@ -4,6 +4,7 @@
     <Button text="Multi Template" [nsRouterLink]="['/multi']" class="btn btn-primary"></Button>
     <Button row="1" text="Pager With List" [nsRouterLink]="['/list']" class="btn btn-primary"></Button>
     <Button row="2" text="Pager With Static Content" [nsRouterLink]="['/static']" class="btn btn-primary"></Button>
+    <Button row="2" text="Pager With Static Content inside router outlet" [nsRouterLink]="['/router-test/page1']" class="btn btn-primary"></Button>
     <Pager row="3" [items]="items | async" loadMoreCount="5" #pager [selectedIndex]="currentPagerIndex" (selectedIndexChange)="onIndexChanged($event)" class="pager"
         backgroundColor="lightsteelblue">
         <ng-template let-i="index" let-item="item">

--- a/src/angular/pager-items-comp.ts
+++ b/src/angular/pager-items-comp.ts
@@ -71,8 +71,7 @@ export interface SetupItemViewArgs {
     context: ItemContext;
 }
 
-export abstract class TemplatedItemsComponent
-    implements DoCheck, OnDestroy, AfterContentInit {
+export abstract class TemplatedItemsComponent implements DoCheck, OnDestroy, AfterContentInit {
     public abstract get nativeElement(): Pager;
     protected templatedItemsView: Pager;
     protected _items: any;
@@ -365,7 +364,8 @@ export class PagerItemDirective implements OnInit {
 
         if (realViews.length > 0) {
             const view = realViews[0];
-            this.owner.nativeElement._addChildFromBuilder('PagerItem', view);
+            this.item.addChild(view);
+            this.owner.nativeElement._addChildFromBuilder('PagerItem', this.item);
         }
     }
 }

--- a/src/pager.android.ts
+++ b/src/pager.android.ts
@@ -342,6 +342,7 @@ export class Pager extends PagerBase {
     _addChildFromBuilder(name: string, value: any): void {
         if (value instanceof PagerItem) {
             this._childrenViews.set(this._childrenCount, value);
+            this.refresh();
         }
     }
     // public [orientationProperty.setNative](value: Orientation) {

--- a/src/pager.common.ts
+++ b/src/pager.common.ts
@@ -21,7 +21,7 @@ import { Observable } from 'tns-core-modules/data/observable';
 import { addWeakEventListener, removeWeakEventListener } from 'tns-core-modules/ui/core/weak-event-listener';
 import { ItemsSource } from 'tns-core-modules/ui/list-view/list-view';
 import { ObservableArray } from 'tns-core-modules/data/observable-array';
-import { StackLayout } from 'tns-core-modules/ui/layouts/stack-layout';
+import { GridLayout } from 'tns-core-modules/ui/layouts/grid-layout';
 
 export type Orientation = 'horizontal' | 'vertical';
 
@@ -271,7 +271,7 @@ export abstract class PagerBase extends ContainerView implements AddChildFromBui
     abstract _addChildFromBuilder(name: string, value: any): void;
 }
 
-export class PagerItem extends StackLayout {
+export class PagerItem extends GridLayout {
     constructor() {
         super();
     }

--- a/src/pager.d.ts
+++ b/src/pager.d.ts
@@ -26,5 +26,5 @@ export declare class Pager extends PagerBase {
 
     requestLayout(): void;
 
-    _addChildFromBuilder(name: string, value: Array<any>): void;
+    _addChildFromBuilder(name: string, value: any): void;
 }


### PR DESCRIPTION
This pr solves a few issues and adds one more test

1. When using angular the view that was going into `_addChildFromBuilder ` was the Layout where the directive `*pageItem` was applied, but per recent updates this view must wrap around `PageItem`(on recent versions static items didn't appear on ng demo)
2. when using `_addChildFromBuilder ` which is the case when using static items, the adapter doesn't refresh and update its page counter, adding a `refresh` call solved the problem but not sure if it's the right way (this produces the error on #118 )
3. Changed the PageItem extends from `StackLayout` to `GridLayout`

Notes: 
@triniwiz i have also updated dependencies, i can push it if you wish and also bump version
@farfromrefug you might wan't to take a look

Test case related to #118 on first commit