### PR TITLE
fix pager height animation

### DIFF
--- a/src/pager.android.ts
+++ b/src/pager.android.ts
@@ -140,7 +140,7 @@ export class Pager extends PagerBase {
         this.compositeTransformer = new androidx.viewpager2.widget.CompositePageTransformer();
         this.pager.setUserInputEnabled(!this.disableSwipe);
         this.on(View.layoutChangedEvent, this.onLayoutChange, this);
-        nativeView.addView(this.pager);
+        nativeView.addView(this.pager, new android.widget.RelativeLayout.LayoutParams(android.widget.RelativeLayout.LayoutParams.MATCH_PARENT, android.widget.RelativeLayout.LayoutParams.MATCH_PARENT));
         this._indicatorView = new (com as any).rd.PageIndicatorView2(this._context);
         const params = new android.widget.RelativeLayout.LayoutParams(
             android.widget.RelativeLayout.LayoutParams.WRAP_CONTENT,


### PR DESCRIPTION
To make sure it works well during animations we need to make sure the pager width/height always match the holder native view

Without the fix
![May-14-2020 16-57-40](https://user-images.githubusercontent.com/655344/81950368-213e7b80-9604-11ea-8ed8-cf3b78218651.gif)

With the fix
![May-14-2020 16-57-50](https://user-images.githubusercontent.com/655344/81950386-27ccf300-9604-11ea-8c3e-3667e8551d3b.gif)
