### PR TITLE
Some fixes

### DIFF
--- a/src/pager.common.ts
+++ b/src/pager.common.ts
@@ -127,6 +127,10 @@ export abstract class PagerBase
 
     abstract refresh(): void;
 
+    getChildView(index:number) {
+        return this._childrenViews && this._childrenViews.get(index)
+    } 
+
     private _itemTemplateSelector: (
         item: any,
         index: number,

--- a/src/pager.d.ts
+++ b/src/pager.d.ts
@@ -1,7 +1,7 @@
 import { View } from '@nativescript/core';
-import {  PagerBase } from './pager.common';
+import {  PagerBase, PagerItem } from './pager.common';
 
-export { ItemsSource, PagerItem, PagerError, PagerLog } from './pager.common';
+export { ItemsSource, PagerError, PagerLog, PagerItem } from './pager.common';
 export type Orientation = 'horizontal' | 'vertical';
 
 export declare class Pager extends PagerBase {
@@ -30,4 +30,6 @@ export declare class Pager extends PagerBase {
     _addChildFromBuilder(name: string, value: any): void;
 
     _onItemsChanged(oldValue: any, newValue: any);
+
+    getChildView(index:number): PagerItem;
 }

--- a/src/pager.ios.ts
+++ b/src/pager.ios.ts
@@ -320,7 +320,7 @@ export class Pager extends PagerBase {
     [selectedIndexProperty.setNative](value: number) {
         console.log("selectedIndexProperty", value);
         if (this.isLoaded) {
-            this.scrollToIndexAnimated(value, true);
+            this.scrollToIndexAnimated(value, !this.disableAnimation);
         }
     }
 

--- a/src/pager.ios.ts
+++ b/src/pager.ios.ts
@@ -67,6 +67,8 @@ declare var CHIPageControlAji,
 
 const main_queue = dispatch_get_current_queue();
 
+
+const PFLAG_FORCE_LAYOUT = 1;
 export class Pager extends PagerBase {
     lastEvent: number = 0;
     private _disableSwipe: boolean = false;
@@ -82,7 +84,7 @@ export class Pager extends PagerBase {
     backgroundColor: any;
     _isDirty: boolean = false;
     _isRefreshing: boolean = false;
-    private _pager: any; /*UICollectionView*/
+    private _pager: UICollectionView;
     private _indicatorView: any;
     private _observableArrayInstance: ObservableArray<any>;
     _isInit: boolean = false;
@@ -682,13 +684,16 @@ export class Pager extends PagerBase {
             heightMeasureSpec
         );
         super.measure(widthMeasureSpec, heightMeasureSpec);
-        if (changed) {
+		let forceLayout = (this._privateFlags & PFLAG_FORCE_LAYOUT) === PFLAG_FORCE_LAYOUT;
+        if (changed || forceLayout) {
             dispatch_async(main_queue, () => {
                 if (!this.pager) {
                     return;
                 }
                 this.pager.reloadData();
-                this._updateScrollPosition();
+                if (changed) {
+                    this._updateScrollPosition();
+                }
                 this._initAutoPlay(this.autoPlay);
             });
         }

--- a/src/vue/pager.js
+++ b/src/vue/pager.js
@@ -28,7 +28,6 @@ module.exports = function pager(Vue) {
       ref="pagerView"
       :items="items"
       v-bind="$attrs"
-      v-on="listeners"
       :selectedIndex="selectedIndex"
 	  @itemLoading="onItemLoading"
 	  @itemDisposing="onItemDisposing">
@@ -42,13 +41,6 @@ module.exports = function pager(Vue) {
 					this.$refs.pagerView.nativeView.refresh();
 				},
 				deep: true
-			}
-		},
-		computed: {
-			listeners() {
-				return Object.assign({}, this.$listeners, {
-					selectedIndexChange: this.onSelectedIndexChange
-				})
 			}
 		},
 		mounted() {
@@ -88,9 +80,6 @@ module.exports = function pager(Vue) {
 				// if (oldVnode) {
 				// 	Vue.prototype.__patch__(oldVnode, null);
 				// }
-			},
-			onSelectedIndexChange({ value }) {
-				this.$emit('selectedIndexChange', value)
 			}
 		}
 	};


### PR DESCRIPTION
* vue fix for v-model
* getChildView to access static views (need this to call refresh in the child view on selectedIndex change) did not find any other way
* ios: when a requestLayout is called the measurement is not called again on iOS => wrong layout
* disableAnimation was not taken into account on iOS